### PR TITLE
Explicitly set useFindAndModify to false

### DIFF
--- a/lib/mongooseConnect.js
+++ b/lib/mongooseConnect.js
@@ -6,7 +6,8 @@ var options = {
   connectTimeoutMS: 30000,
   useNewUrlParser: true,
   useUnifiedTopology: true,
-  useCreateIndex: true
+  useCreateIndex: true,
+  useFindAndModify: false,
 };
 
 module.exports = new Promise(function(resolve, reject) {


### PR DESCRIPTION
PR related to Mongo 4.0 migration routific/routific-node-api#2885

We are explicitly setting the useFindAndModify that already defaults to false as the true usage case is deprecated.